### PR TITLE
Avoid call tree.children if not editor exists

### DIFF
--- a/src/symbolOutline.ts
+++ b/src/symbolOutline.ts
@@ -107,7 +107,9 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
             return node.children;
         } else {
             await this.updateSymbols(window.activeTextEditor);
-            return this.tree.children;
+            if (this.tree) {
+                return this.tree.children;
+            }
         }
     }
 


### PR DESCRIPTION
Hi @patrys This PR fixs #11: property children of undefined