### PR TITLE
Show tree view nodes even if the container cannot be found.

### DIFF
--- a/src/symbolOutline.ts
+++ b/src/symbolOutline.ts
@@ -68,12 +68,12 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
         if (editor) {
             const symbols = await this.getSymbols(editor.document);
             symbols.reduce((knownContainerScopes, symbol) => {
-                let parent: SymbolNode;
-                const node = new SymbolNode(symbol);
-                if (!(symbol.containerName in knownContainerScopes)) {
-                    return knownContainerScopes;
+                let parent: SymbolNode = knownContainerScopes[''];
+                if (symbol.containerName in knownContainerScopes) {
+                    parent = knownContainerScopes[symbol.containerName];
                 }
-                parent = knownContainerScopes[symbol.containerName];
+
+                const node = new SymbolNode(symbol);
                 parent.addChild(node);
                 return {...knownContainerScopes, [symbol.name]: node};
             }, {'': tree});


### PR DESCRIPTION
An extension can reuse the containerName structure for other purposes.
There is also no guarantee that the container has already been seen
(maybe it is coming later).