### PR TITLE
Added two options doSelect and autoExpand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Default settings:
 {
   "symbolOutline.doSort": true,
   "symbolOutline.doSelect": true,
-  "symbolOutline.autoExpand": true,
   "symbolOutline.sortOrder": [
     "Class",
     "Module",
@@ -29,6 +28,15 @@ Default settings:
     "Function",
     "Method"
   ],
+  "symbolOutline.expandNodes": [
+    "Module",
+    "Class",
+    "Interface",
+    "Namespace",
+    "Object",
+    "Package",
+    "Struct"
+  ],
   "symbolOutline.topLevel": [
     "*"
   ]
@@ -37,7 +45,7 @@ Default settings:
 
 - **doSort:** sort the outline.
 - **doSelect:** select the code segment by selecting item.
-- **autoExpand:** auto expand the tree (except function node).
+- **expandNodes:** kinds of nodes to be expanded automatically.
 - **sortOrder:** order to the sort symbols.
 - **topLevel:** wich symbols include at the topmost scope.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Default settings:
 {
   "symbolOutline.doSort": true,
   "symbolOutline.doSelect": true,
-  "symbolOutline.autoExpend": true,
+  "symbolOutline.autoExpand": true,
   "symbolOutline.sortOrder": [
     "Class",
     "Module",
@@ -37,7 +37,7 @@ Default settings:
 
 - **doSort:** sort the outline.
 - **doSelect:** select the code segment by selecting item.
-- **autoExpend:** auto expend the tree (except function node).
+- **autoExpand:** auto expand the tree (except function node).
 - **sortOrder:** order to the sort symbols.
 - **topLevel:** wich symbols include at the topmost scope.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Default settings:
 ```json
 {
   "symbolOutline.doSort": true,
+  "symbolOutline.doSelect": true,
+  "symbolOutline.autoExpend": true,
   "symbolOutline.sortOrder": [
     "Class",
     "Module",
@@ -34,6 +36,8 @@ Default settings:
 ```
 
 - **doSort:** sort the outline.
+- **doSelect:** select the code segment by selecting item.
+- **autoExpend:** auto expend the tree (except function node).
 - **sortOrder:** order to the sort symbols.
 - **topLevel:** wich symbols include at the topmost scope.
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
                     "default": true,
                     "description": "Sort the outline"
                 },
+                "symbolOutline.autoExpend": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Auto expend the tree (except function node)."
+                },
                 "symbolOutline.doSelect": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
                     "default": true,
                     "description": "Sort the outline"
                 },
-                "symbolOutline.autoExpend": {
+                "symbolOutline.autoExpand": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Auto expend the tree (except function node)."
+                    "description": "Auto expand the tree (except function node)."
                 },
                 "symbolOutline.doSelect": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
                     "default": true,
                     "description": "Sort the outline"
                 },
+                "symbolOutline.doSelect": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Select the code segment by selecting item."
+                },
                 "symbolOutline.sortOrder": {
                     "type": "array",
                     "default": [

--- a/package.json
+++ b/package.json
@@ -61,10 +61,18 @@
                     "default": true,
                     "description": "Sort the outline"
                 },
-                "symbolOutline.autoExpand": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Auto expand the tree (except function node)."
+                "symbolOutline.expandNodes": {
+                    "type": "array",
+                    "default": [
+                        "Module",
+                        "Class",
+                        "Interface",
+                        "Namespace",
+                        "Object",
+                        "Package",
+                        "Struct"
+                    ],
+                    "description": "Kinds of nodes to be expanded automatically."
                 },
                 "symbolOutline.doSelect": {
                     "type": "boolean",

--- a/src/symbolOutline.ts
+++ b/src/symbolOutline.ts
@@ -5,6 +5,7 @@ let optsSortOrder: number[] = [];
 let optsTopLevel: number[] = [];
 let optsDoSort = true;
 let optsDoSelect = true;
+let optsAutoExpend = true;
 
 export class SymbolNode {
     symbol: SymbolInformation;
@@ -152,7 +153,28 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
     getTreeItem(node: SymbolNode): TreeItem {
         const { kind } = node.symbol;
         let treeItem = new TreeItem(node.symbol.name);
-        treeItem.collapsibleState = node.children.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+
+        if (optsAutoExpend && node.children.length) {
+
+            switch (kind) {
+            case SymbolKind.Module:
+            case SymbolKind.Namespace:
+            case SymbolKind.Object:
+            case SymbolKind.Package:
+            case SymbolKind.Interface:
+            case SymbolKind.Struct:
+            case SymbolKind.Class:
+                treeItem.collapsibleState = TreeItemCollapsibleState.Expanded;
+                break;
+            default:
+                treeItem.collapsibleState = TreeItemCollapsibleState.Collapsed;
+            };
+        }
+        else {
+
+            treeItem.collapsibleState = node.children.length ?
+                TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+        }
 
         treeItem.command = {
             command: 'symbolOutline.revealRange',
@@ -179,6 +201,7 @@ function readOpts() {
    let opts = workspace.getConfiguration("symbolOutline");
    optsDoSort = opts.get<boolean>("doSort");
    optsDoSelect = opts.get<boolean>("doSelect");
+   optsAutoExpend = opts.get<boolean>("autoExpend");
    optsSortOrder = convertEnumNames(opts.get<string[]>("sortOrder"));
    optsTopLevel = convertEnumNames(opts.get<string[]>("topLevel"));
 }

--- a/src/symbolOutline.ts
+++ b/src/symbolOutline.ts
@@ -1,9 +1,10 @@
-import { Event, EventEmitter, ExtensionContext, SymbolKind, SymbolInformation, TextDocument, TextEditor, TreeDataProvider, TreeItem, TreeItemCollapsibleState, commands, window, workspace } from 'vscode';
+import { Range, Event, EventEmitter, ExtensionContext, SymbolKind, SymbolInformation, TextDocument, TextEditor, TreeDataProvider, TreeItem, TreeItemCollapsibleState, commands, window, workspace } from 'vscode';
 import * as path from 'path';
 
 let optsSortOrder: number[] = [];
 let optsTopLevel: number[] = [];
 let optsDoSort = true;
+let optsDoSelect = true;
 
 export class SymbolNode {
     symbol: SymbolInformation;
@@ -152,11 +153,19 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
         const { kind } = node.symbol;
         let treeItem = new TreeItem(node.symbol.name);
         treeItem.collapsibleState = node.children.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
+
         treeItem.command = {
             command: 'symbolOutline.revealRange',
             title: '',
-            arguments: [this.editor, node.symbol.location.range]
+            arguments: [
+                this.editor,
+                optsDoSelect ? node.symbol.location.range : new Range(
+                    node.symbol.location.range.start,
+                    node.symbol.location.range.start
+                )
+            ]
         };
+
         treeItem.iconPath = this.getIcon(kind);
         return treeItem;
     }
@@ -169,6 +178,7 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
 function readOpts() {
    let opts = workspace.getConfiguration("symbolOutline");
    optsDoSort = opts.get<boolean>("doSort");
+   optsDoSelect = opts.get<boolean>("doSelect");
    optsSortOrder = convertEnumNames(opts.get<string[]>("sortOrder"));
    optsTopLevel = convertEnumNames(opts.get<string[]>("topLevel"));
 }

--- a/src/symbolOutline.ts
+++ b/src/symbolOutline.ts
@@ -5,7 +5,7 @@ let optsSortOrder: number[] = [];
 let optsTopLevel: number[] = [];
 let optsDoSort = true;
 let optsDoSelect = true;
-let optsAutoExpend = true;
+let optsAutoExpand = true;
 
 export class SymbolNode {
     symbol: SymbolInformation;
@@ -154,7 +154,7 @@ export class SymbolOutlineProvider implements TreeDataProvider<SymbolNode> {
         const { kind } = node.symbol;
         let treeItem = new TreeItem(node.symbol.name);
 
-        if (optsAutoExpend && node.children.length) {
+        if (optsAutoExpand && node.children.length) {
 
             switch (kind) {
             case SymbolKind.Module:
@@ -201,7 +201,7 @@ function readOpts() {
    let opts = workspace.getConfiguration("symbolOutline");
    optsDoSort = opts.get<boolean>("doSort");
    optsDoSelect = opts.get<boolean>("doSelect");
-   optsAutoExpend = opts.get<boolean>("autoExpend");
+   optsAutoExpand = opts.get<boolean>("autoExpand");
    optsSortOrder = convertEnumNames(opts.get<string[]>("sortOrder"));
    optsTopLevel = convertEnumNames(opts.get<string[]>("topLevel"));
 }


### PR DESCRIPTION
Added two options:
- `doSelect`: set to false so you can disable auto-selecting code segment by clicking tree item. (issue #31 )
- `autoExpend`: set to true and then the tree will be expanded automatically except function node. (issue #21 )