### PR TITLE
Add powershell to supported in code outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Here is a list of languages known to work with Code Outline:
 | Markdown | Comes with VS Code |
 | Perl | [Perl](https://marketplace.visualstudio.com/items?itemName=henriiik.vscode-perl) |
 | PHP | [PHP Symbols](https://marketplace.visualstudio.com/items?itemName=linyang95.php-symbols) |
+| Powershell | [Powershell](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) |
 | Python | [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) |
 | TypeScript | Comes with VS Code |
 | YAML | [YAML Support by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) |


### PR DESCRIPTION
Code outline works with no additional configuration needed for powershell beyond simply having both code outline and the powershell extension installed.

It does not however work with the built in powershell language basics built into vs code itself.
There's no changes to powershell basics from VS 1.22.1 -> 1.23 (latest) with regards to emitting what code outline needs, so it specifically only works with the extension and not the built in basics extension as of the moment.

Versions tested:
* Windows 10 Pro v1609 x64
* VS code: 1.22.1 x64
* Powershell basics extension 1.0.0 (built in to vscode)
* Powershell (language support) extension 1.6.0